### PR TITLE
sshd on Fedora logs the public key fingerprint

### DIFF
--- a/regex.c
+++ b/regex.c
@@ -17,7 +17,7 @@ static struct log_pattern matches[] = {
 	}, {
 		.regex = "User .{0,100} from " IP_PATTERN " not allowed because not listed in AllowUsers$",
 	}, {
-		.regex = "Accepted publickey for .{0,100} from " IP_PATTERN " port [0-9]{1,5} ssh2$",
+		.regex = "Accepted publickey for .{0,100} from " IP_PATTERN " port [0-9]{1,5} ssh2",
 		.is_whitelist = true,
 	},
 };


### PR DESCRIPTION
for example:
Accepted publickey for ruben from x.x.x.x port 57452
ssh2: RSA d4:65:ea:25:96:22:c6:72:53:33:91:5a:78:1e:24:69